### PR TITLE
GeoCell size default fix

### DIFF
--- a/ether/cell.py
+++ b/ether/cell.py
@@ -166,7 +166,14 @@ class SharedLinkCell(Cell):
 
 class GeoCell(Cell):
 
-    def __init__(self, size, density, nodes) -> None:
+    def __init__(self, density, nodes, size: int = 1) -> None:
+        """
+        Initializes the GeoCell :param density: int or Randomsampler. Used to divide the nodes in the cells :param
+        nodes: nodes the GeoCell will contain :param size: Number of times GeoCell will iterate over the nodes when
+        materializing. ATTENTION: If you want to supply your own nodes that aren't themselves generators,
+        this must be 1, since otherwise materialize will be called n times on your nodes, depending on what size you
+        choose
+        """
         super().__init__(nodes, size)
         if isinstance(density, int):
             self.density = ConstantSampler(density)
@@ -176,7 +183,7 @@ class GeoCell(Cell):
             raise ValueError('unknown density type %s' % type(density))
 
     def materialize(self, topology: Topology, parent=None):
-        for i in range(self.size):
+        for _ in range(self.size):
             n = self.density.sample()
 
             for c in self.nodes:

--- a/ether/scenarios/urbansensing.py
+++ b/ether/scenarios/urbansensing.py
@@ -51,7 +51,7 @@ class UrbanSensingScenario:
             backhaul=MobileConnection(self.internet)
         )
 
-        city = GeoCell(self.num_cells, nodes=[neighborhood], density=self.cell_density)
+        city = GeoCell(size=self.num_cells, nodes=[neighborhood], density=self.cell_density)
 
         return city
 

--- a/examples/urbansensing.py
+++ b/examples/urbansensing.py
@@ -32,7 +32,7 @@ def main():
         shared_bandwidth=500,
         backhaul=MobileConnection('internet_chix'))
     city = GeoCell(
-        5, nodes=[neighborhood], density=lognorm((0.82, 2.02)))
+        size=5, nodes=[neighborhood], density=lognorm((0.82, 2.02)))
     cloudlet = Cloudlet(
         5, 2, backhaul=FiberToExchange('internet_chix'))
 

--- a/examples/vivaldi/urban_sensing.py
+++ b/examples/vivaldi/urban_sensing.py
@@ -47,7 +47,7 @@ def create_topology() -> Topology:
             nodes=[[aot_node] * size, [edge_broker_factory_with_region(region)]],
             backhaul=MobileConnection(region)
         )
-        city = GeoCell(5, nodes=[neighborhood], density=lognorm((0.82, 2.02)))
+        city = GeoCell(size=5, nodes=[neighborhood], density=lognorm((0.82, 2.02)))
         topology.add(city)
 
         broker = Broker(f'cloud-broker_{region}', backhaul=region)


### PR DESCRIPTION
This should help prevent bugs in the future, since some bugs already occurred that would have been mitigated by the changes signature and documentation.

ATTENTION: This is a breaking change, since it alters the constructor signature of GeoCell. I understand if that isn't acceptable. In that case at least the documentation should remain.

The bug is the following: When using GeoCell, the size determines how often the nodes supplied are iterated on. This is perfectly fine when the 'nodes' are functions that generate those nodes, i.e. if they are callable. If they aren't, however, because someone wanted to supply nodes directly (which is clearly a valid use case since this is specifically checked for in the code), the nodes are materialized instead. Now this is fine generally speaking, but if size > 1, then materialize is called more than once per node, which is incorrect behavior and leads to an incorrect topology.

Because of that I figured it would make sense to change the signature to a variable with a default value of 1, such that someone not knowing what this parameter affects exactly uses a value that doesn't cause problems. I also added documentation outlining that behaviour.

EDIT: This is what a topology looks like if GeoCell is used in the way I outlined:
![image](https://user-images.githubusercontent.com/9217404/122446034-7f295980-cfa2-11eb-8ad2-5b5e95b9a3bd.png)
It should look like this instead:
![image](https://user-images.githubusercontent.com/9217404/122446156-a1bb7280-cfa2-11eb-9ba0-c1cae45103b7.png)
